### PR TITLE
Correctly handle DW_FORM_flag and add DW_FORM_flag_present support

### DIFF
--- a/dwarf_loader.c
+++ b/dwarf_loader.c
@@ -241,7 +241,12 @@ static uint64_t attr_numeric(Dwarf_Die *die, uint32_t name)
 	}
 		break;
 	case DW_FORM_flag:
-		return 1;
+	case DW_FORM_flag_present: {
+		bool value;
+		if (dwarf_formflag(&attr, &value) == 0)
+			return value;
+	}
+		break;
 	default:
 		fprintf(stderr, "DW_AT_<0x%x>=0x%x\n", name, form);
 		break;


### PR DESCRIPTION
Before this patch, running pahole on an executable compiled
with -gdwarf-4 gave:

DW_AT_<0x3c>=0x19

0x19 is DW_FORM_flag_present.
Also, DW_FORM_flag takes an argument.
Changing attr_numeric to call dwarf_formflag fixes both problems.
