### PR TITLE
dwarves: support DW_TAG_atomic_type

### DIFF
--- a/dwarf_loader.c
+++ b/dwarf_loader.c
@@ -770,7 +770,8 @@ static int tag__recode_dwarf_bitfield(struct tag *tag, struct cu *cu, uint16_t b
 		break;
 
 	case DW_TAG_const_type:
-	case DW_TAG_volatile_type: {
+	case DW_TAG_volatile_type:
+	case DW_TAG_atomic_type: {
 		const struct dwarf_tag *dtag = tag->priv;
 		struct dwarf_tag *dtype = dwarf_cu__find_type_by_ref(cu->priv, &dtag->type);
 
@@ -1990,6 +1991,7 @@ static struct tag *__die__process_tag(Dwarf_Die *die, struct cu *cu,
 	case DW_TAG_restrict_type:
 	case DW_TAG_unspecified_type:
 	case DW_TAG_volatile_type:
+	case DW_TAG_atomic_type:
 		tag = die__create_new_tag(die, cu);		break;
 	case DW_TAG_pointer_type:
 		tag = die__create_new_pointer_tag(die, cu, conf);	break;

--- a/dwarves.c
+++ b/dwarves.c
@@ -388,7 +388,8 @@ reevaluate:
 		case DW_TAG_const_type:
 		case DW_TAG_typedef:
 		case DW_TAG_rvalue_reference_type:
-		case DW_TAG_volatile_type: {
+		case DW_TAG_volatile_type:
+		case DW_TAG_atomic_type: {
 			struct tag *tag = cu__type(cu, type->type);
 			if (tag == NULL) {
 				tag__id_not_found_fprintf(stderr, type->type);

--- a/dwarves.h
+++ b/dwarves.h
@@ -487,6 +487,11 @@ static inline bool tag__is_volatile(const struct tag *tag)
 	return tag->tag == DW_TAG_volatile_type;
 }
 
+static inline bool tag__is_atomic(const struct tag *tag)
+{
+	return tag->tag == DW_TAG_atomic_type;
+}
+
 static inline bool tag__is_restrict(const struct tag *tag)
 {
 	return tag->tag == DW_TAG_restrict_type;
@@ -496,7 +501,8 @@ static inline int tag__is_modifier(const struct tag *tag)
 {
 	return tag__is_const(tag) ||
 	       tag__is_volatile(tag) ||
-	       tag__is_restrict(tag);
+	       tag__is_restrict(tag) ||
+	       tag__is_atomic(tag);
 }
 
 static inline bool tag__has_namespace(const struct tag *tag)
@@ -539,6 +545,7 @@ static inline int tag__is_tag_type(const struct tag *tag)
 	       tag->tag == DW_TAG_subroutine_type ||
 	       tag->tag == DW_TAG_unspecified_type ||
 	       tag->tag == DW_TAG_volatile_type ||
+	       tag->tag == DW_TAG_atomic_type ||
 	       tag->tag == DW_TAG_LLVM_annotation;
 }
 

--- a/dwarves_emit.c
+++ b/dwarves_emit.c
@@ -262,6 +262,7 @@ next_indirection:
 	case DW_TAG_array_type:
 	case DW_TAG_const_type:
 	case DW_TAG_volatile_type:
+	case DW_TAG_atomic_type:
 		type = cu__type(cu, type->type);
 		if (type == NULL)
 			return 0;

--- a/dwarves_fprintf.c
+++ b/dwarves_fprintf.c
@@ -93,6 +93,7 @@ static const char *dwarf_tag_names[] = {
 	[DW_TAG_skeleton_unit]		  = "skeleton_unit",
 	[DW_TAG_immutable_type]		  = "immutable_type",
 #endif
+	[DW_TAG_atomic_type]		  = "atomic_type",
 };
 
 static const char *dwarf_gnu_tag_names[] = {
@@ -562,6 +563,7 @@ static const char *__tag__name(const struct tag *tag, const struct cu *cu,
 	case DW_TAG_volatile_type:
 	case DW_TAG_const_type:
 	case DW_TAG_restrict_type:
+	case DW_TAG_atomic_type:
 	case DW_TAG_unspecified_type:
 		type = cu__type(cu, tag->type);
 		if (type == NULL && tag->type != 0)
@@ -576,6 +578,7 @@ static const char *__tag__name(const struct tag *tag, const struct cu *cu,
 			case DW_TAG_volatile_type: prefix = "volatile "; break;
 			case DW_TAG_const_type:    prefix = "const ";	 break;
 			case DW_TAG_restrict_type: suffix = " restrict"; break;
+			case DW_TAG_atomic_type:   prefix = "_Atomic ";  break;
 			}
 			snprintf(bf, len, "%s%s%s ", prefix, type_str, suffix);
 		}


### PR DESCRIPTION
Throwing userspace programs with atomic types at pahole currently
results in either odd results (struct fiels with zero length) or
straight up segfaults (dereferencing a NULL tag).

Add DW_TAG_atomic_type analogous to DW_TAG_volatile_type (which it
behaves identically to.)

---
Not sure if this needs to be submitted on some mailing list?