### PR TITLE
pahole: expand named typedefs if expanding types is requested

### DIFF
--- a/dwarves_fprintf.c
+++ b/dwarves_fprintf.c
@@ -345,7 +345,7 @@ next_type:
 	case DW_TAG_structure_type: {
 		struct type *ctype = tag__type(tag_type);
 
-		if (type__name(ctype) != NULL)
+		if (type__name(ctype) != NULL && conf->expand_types != true)
 			return printed + fprintf(fp, "struct %s %s", type__name(ctype), type__name(type));
 
 		struct conf_fprintf tconf = *pconf;


### PR DESCRIPTION
If your code contains named typedefs like

typedef struct foo_s {
        /*some stuff here*/
}foo;

and your run pahole with something like pahole -E -C foo <ELF> it only prints something like this

typedef struct foo_s foo

I think what the user would like (at least this is what I was expecting) is that the typedef is expanded.

I know that this is irrelevant for the linux kernel because nobody is doing such silly stuff there. But there is a lot of strange software out there which typedefs nearly every structure for some reason.

I think applying this patch would make pahole -E more intuitive

Signed-off-by: Wadim Mueller <wafgo01@gmail.com>