### PR TITLE
fix segmentfault when exec dtagnames or prefcnt without any args

### DIFF
--- a/btf_loader.c
+++ b/btf_loader.c
@@ -648,6 +648,9 @@ static int cus__load_btf(struct cus *cus, struct conf_load *conf, const char *fi
 {
 	int err = -1;
 
+	if (conf == NULL)
+		return -1;
+
 	// Pass a zero for addr_size, we'll get it after we load via btf__pointer_size()
 	struct cu *cu = cu__new(filename, 0, NULL, 0, filename, false);
 	if (cu == NULL)

--- a/dwarf_loader.c
+++ b/dwarf_loader.c
@@ -3315,6 +3315,9 @@ static int dwarf__load_file(struct cus *cus, struct conf_load *conf,
 {
 	int fd, err;
 
+	if (conf == NULL)
+		return -1;
+
 	if (conf->max_hashtable_bits != 0) {
 		if (conf->max_hashtable_bits > 31)
 			return -E2BIG;


### PR DESCRIPTION
while exec dtagnames or prefnct without any args, will get segement fault result.

```
# prefcnt
Segmentation fault (core dumped)

```

gdb info

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  cus__load_btf (cus=0x55eb480132a0, conf=0x0, filename=0x7fddd3215241 "/sys/kernel/btf/vmlinux")
```