### PR TITLE
cmake: Use GNUInstallDirs to install data directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,11 +178,11 @@ install(FILES dwarves.h dwarves_emit.h dwarves_reorganize.h
 	      btf_encoder.h config.h ctf.h
 	      elfcreator.h elf_symtab.h hash.h libctf.h
 	DESTINATION ${CMAKE_INSTALL_PREFIX}/include/dwarves/)
-install(FILES man-pages/pahole.1 DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man1/)
+install(FILES man-pages/pahole.1 DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/man/man1/")
 if(Python3_FOUND)
 	install(PROGRAMS ostra/ostra-cg DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-	install(FILES ostra/python/ostra.py DESTINATION ${CMAKE_INSTALL_PREFIX}/share/dwarves/runtime/python)
+	install(FILES ostra/python/ostra.py DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/dwarves/runtime/python")
 endif()
 install(PROGRAMS btfdiff fullcircle DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 install(FILES lib/Makefile lib/ctracer_relay.c lib/ctracer_relay.h lib/linux.blacklist.cu
-	DESTINATION ${CMAKE_INSTALL_PREFIX}/share/dwarves/runtime)
+	DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/dwarves/runtime")


### PR DESCRIPTION
Solves issues with cross environments where prefix is set to e.g. `-DCMAKE_INSTALL_PREFIX:PATH=/usr/x86_64-pc-linux-gnu` and the arch independent files would end up under the prefix as well instead of `/usr/share`.

Note: variables offered by CMake `GNUInstallDirs` could probably be used for the various other stuff as well like for getting rid of the `__lib` hack by using `CMAKE_INSTALL_LIBDIR` but I just wanted to solve an actual issue I ran across with this PR.