### PR TITLE
Fix pahole segfault with --show_reorg_steps option

### DIFF
--- a/dwarves_fprintf.c
+++ b/dwarves_fprintf.c
@@ -1861,7 +1861,7 @@ static size_t __class__fprintf(struct class *class, const struct cu *cu,
 		}
 		printed += fprintf(fp, " */\n");
 	}
-	cacheline = (cconf.base_offset + type->size) % conf_fprintf__cacheline_size(conf);
+	cacheline = (cconf.base_offset + type->size) % conf_fprintf__cacheline_size(&cconf);
 	if (cacheline != 0)
 		printed += fprintf(fp, "%.*s/* last cacheline: %u bytes */\n",
 				   cconf.indent, tabs,


### PR DESCRIPTION
This function call seems to mistakenly use `conf` directly rather than `cconf` which protects against `conf` being null:
https://github.com/acmel/dwarves/blob/c129fa7579483bba5b050ba54cc683e11d2b70f3/dwarves_fprintf.c#L1484

This makes pahole segfault seemingly whenever `--show_reorg_steps` is used