### PR TITLE
man-pages: Fix incorrect command line argument in documentation

### DIFF
--- a/man-pages/pahole.1
+++ b/man-pages/pahole.1
@@ -398,11 +398,11 @@ Show only structs that has holes that can be packed if members are reorganized,
 for instance when using the \fB\-\-reorganize\fR option.
 
 .TP
-.B \-P, \-\-with_flexible_array
+.B     \-\-with_flexible_array
 Show only structs that have a flexible array.
 
 .TP
-.B \-P, \-\-with_embedded_flexible_array
+.B     \-\-with_embedded_flexible_array
 Show only structs that have an embedded flexible array, i.e. a contained struct that has flexible arrays, a flexible array "in the middle".
 
 .TP


### PR DESCRIPTION
The --with_flexible_array and --with_embedded_flexible_array arguments were wrongly documented with the short argument '-P' (copy-paste mistake from previous argument), remove it.

Fixes: 7eea706c1499 ("pahole: Introduce --with_flexible_array option to show just types ending in a flexible array")
Fixes: 446c28d118b9 ("pahole: Introduce --with_embedded_flexible_array")